### PR TITLE
Bareword fix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,55 +50,55 @@ class selenium (
   $udev_reverse_tether_rules_location = '/etc/udev/rules.d/81-selenium.rules'
 
   $java = $::osfamily ? {
-    windows => 'java',
-    default => '/usr/bin/java',
+    'windows' => 'java',
+    default   => '/usr/bin/java',
   }
 
   $adb_location = "${android_home}/platform-tools/adb"
 
   $config_path  = $::osfamily ? {
-    windows => 'c:/Program Files/selenium/conf',
-    default => '/etc/selenium',
+    'windows' => 'c:/Program Files/selenium/conf',
+    default   => '/etc/selenium',
   }
 
   $selenium_dir = $::osfamily ? {
-    Darwin  => "/Users/${user}/selenium",
-    windows => 'c:/Program Files/selenium',
-    default => '/opt/selenium',
+    'Darwin'  => "/Users/${user}/selenium",
+    'windows' => 'c:/Program Files/selenium',
+    default   => '/opt/selenium',
   }
 
   $selenium_jar = "${selenium_dir}/server.jar"
 
   $appium_path = $::osfamily ? {
-    Darwin  => '/usr/local/lib/node_modules/appium',
-    windows => 'c:/Program Files/nodejs/node_modules/appium',
-    default => '/usr/lib/node_modules/appium',
+    'Darwin'  => '/usr/local/lib/node_modules/appium',
+    'windows' => 'c:/Program Files/nodejs/node_modules/appium',
+    default   => '/usr/lib/node_modules/appium',
   }
 
   $node_executable = $::osfamily ? {
-    Darwin  => '/usr/local/bin/node',
-    windows => 'c:/Program Files/nodejs/node',
-    default => '/usr/bin/node',
+    'Darwin'  => '/usr/local/bin/node',
+    'windows' => 'c:/Program Files/nodejs/node',
+    default   => '/usr/bin/node',
   }
 
   $chromedriver_path = $::osfamily ? {
-    Darwin  => '/usr/local/bin/chromedriver',
-    windows => "${selenium_dir}/chromedriver.exe",
-    default => '/usr/bin/chromedriver',
+    'Darwin'  => '/usr/local/bin/chromedriver',
+    'windows' => "${selenium_dir}/chromedriver.exe",
+    default   => '/usr/bin/chromedriver',
   }
 
   $iedriver_path = "${selenium_dir}/IEDriverServer.exe"
 
   $capabilities = $::osfamily ? {
-    Darwin  => [
+    'Darwin'  => [
       {browserName => 'safari',  maxInstances => 5}
     ],
-    windows => [
+    'windows' => [
       {browserName => 'chrome',            maxInstances => 5},
       {browserName => 'firefox',           maxInstances => 5},
       {browserName => 'internet explorer', maxInstances => 1}
     ],
-    default => [
+    default   => [
       {browserName => 'chrome',  maxInstances => 5},
       {browserName => 'firefox', maxInstances => 5}
     ],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,55 +50,55 @@ class selenium (
   $udev_reverse_tether_rules_location = '/etc/udev/rules.d/81-selenium.rules'
 
   $java = $::osfamily ? {
-    'windows' => 'java',
-    default   => '/usr/bin/java',
+    windows => 'java',
+    default => '/usr/bin/java',
   }
 
   $adb_location = "${android_home}/platform-tools/adb"
 
   $config_path  = $::osfamily ? {
-    'windows' => 'c:/Program Files/selenium/conf',
-    default   => '/etc/selenium',
+    windows => 'c:/Program Files/selenium/conf',
+    default => '/etc/selenium',
   }
 
   $selenium_dir = $::osfamily ? {
-    'Darwin'  => "/Users/${user}/selenium",
-    'windows' => 'c:/Program Files/selenium',
-    default   => '/opt/selenium',
+    Darwin  => "/Users/${user}/selenium",
+    windows => 'c:/Program Files/selenium',
+    default => '/opt/selenium',
   }
 
   $selenium_jar = "${selenium_dir}/server.jar"
 
   $appium_path = $::osfamily ? {
-    'Darwin'  => '/usr/local/lib/node_modules/appium',
-    'windows' => 'c:/Program Files/nodejs/node_modules/appium',
-    default   => '/usr/lib/node_modules/appium',
+    Darwin  => '/usr/local/lib/node_modules/appium',
+    windows => 'c:/Program Files/nodejs/node_modules/appium',
+    default => '/usr/lib/node_modules/appium',
   }
 
   $node_executable = $::osfamily ? {
-    'Darwin'  => '/usr/local/bin/node',
-    'windows' => 'c:/Program Files/nodejs/node',
-    default   => '/usr/bin/node',
+    Darwin  => '/usr/local/bin/node',
+    windows => 'c:/Program Files/nodejs/node',
+    default => '/usr/bin/node',
   }
 
   $chromedriver_path = $::osfamily ? {
-    'Darwin'  => '/usr/local/bin/chromedriver',
-    'windows' => "${selenium_dir}/chromedriver.exe",
-    default   => '/usr/bin/chromedriver',
+    Darwin  => '/usr/local/bin/chromedriver',
+    windows => "${selenium_dir}/chromedriver.exe",
+    default => '/usr/bin/chromedriver',
   }
 
   $iedriver_path = "${selenium_dir}/IEDriverServer.exe"
 
   $capabilities = $::osfamily ? {
-    'Darwin'  => [
+    Darwin  => [
       {browserName => 'safari',  maxInstances => 5}
     ],
-    'windows' => [
+    windows => [
       {browserName => 'chrome',            maxInstances => 5},
       {browserName => 'firefox',           maxInstances => 5},
       {browserName => 'internet explorer', maxInstances => 1}
     ],
-    default   => [
+    default => [
       {browserName => 'chrome',  maxInstances => 5},
       {browserName => 'firefox', maxInstances => 5}
     ],

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -27,7 +27,7 @@ define selenium::service (
   }
 
   case $::osfamily {
-    'Darwin': {
+    Darwin: {
       $plist_label = "com.selenium.${service_name}.server"
       $plist = "/Users/${user}/Library/LaunchAgents/${plist_label}.plist"
       # Mac OS X requires appium to run as an interactive user (i.e. logged in)
@@ -41,7 +41,7 @@ define selenium::service (
         content => template('selenium/service-plist.erb'),
       }
     }
-    'windows': {
+    windows: {
       $batch = "c:/Users/${user}/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/Startup/selenium-${service_name}.bat"
 
       file { $batch :

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -27,7 +27,7 @@ define selenium::service (
   }
 
   case $::osfamily {
-    Darwin: {
+    'Darwin': {
       $plist_label = "com.selenium.${service_name}.server"
       $plist = "/Users/${user}/Library/LaunchAgents/${plist_label}.plist"
       # Mac OS X requires appium to run as an interactive user (i.e. logged in)
@@ -41,7 +41,7 @@ define selenium::service (
         content => template('selenium/service-plist.erb'),
       }
     }
-    windows: {
+    'windows': {
       $batch = "c:/Users/${user}/AppData/Roaming/Microsoft/Windows/Start Menu/Programs/Startup/selenium-${service_name}.bat"
 
       file { $batch :


### PR DESCRIPTION
Use strings instead of barewords for compatibility with later versions of Puppet 4.
