### PR TITLE
Replace Darwin with darwin in osfamily checks

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,7 @@ class selenium (
   }
 
   $selenium_dir = $::osfamily ? {
-    Darwin  => "/Users/${user}/selenium",
+    darwin  => "/Users/${user}/selenium",
     windows => 'c:/Program Files/selenium',
     default => '/opt/selenium',
   }
@@ -70,19 +70,19 @@ class selenium (
   $selenium_jar = "${selenium_dir}/server.jar"
 
   $appium_path = $::osfamily ? {
-    Darwin  => '/usr/local/lib/node_modules/appium',
+    darwin  => '/usr/local/lib/node_modules/appium',
     windows => 'c:/Program Files/nodejs/node_modules/appium',
     default => '/usr/lib/node_modules/appium',
   }
 
   $node_executable = $::osfamily ? {
-    Darwin  => '/usr/local/bin/node',
+    darwin  => '/usr/local/bin/node',
     windows => 'c:/Program Files/nodejs/node',
     default => '/usr/bin/node',
   }
 
   $chromedriver_path = $::osfamily ? {
-    Darwin  => '/usr/local/bin/chromedriver',
+    darwin  => '/usr/local/bin/chromedriver',
     windows => "${selenium_dir}/chromedriver.exe",
     default => '/usr/bin/chromedriver',
   }
@@ -90,7 +90,7 @@ class selenium (
   $iedriver_path = "${selenium_dir}/IEDriverServer.exe"
 
   $capabilities = $::osfamily ? {
-    Darwin  => [
+    darwin  => [
       {browserName => 'safari',  maxInstances => 5}
     ],
     windows => [

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -20,14 +20,14 @@ define selenium::service (
   $service_name     = $name,
 ) {
   # Check if we need to run this service headlessly. THIS DOES NOT WORK ON
-  # Darwin or Windows
+  # darwin or Windows
   $actual_command = $headless ? {
     true    => concat([$headless_command], $command),
     default => $command,
   }
 
   case $::osfamily {
-    Darwin: {
+    darwin: {
       $plist_label = "com.selenium.${service_name}.server"
       $plist = "/Users/${user}/Library/LaunchAgents/${plist_label}.plist"
       # Mac OS X requires appium to run as an interactive user (i.e. logged in)

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,6 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2 <2.0.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2 <=2.2.1" }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,6 @@
     }
    ],
   "dependencies": [
-    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2 <=2.2.1" }
+    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.2 <=5.0.0" }
   ]
 }


### PR DESCRIPTION
Puppet runs on Windows fail with following error:
"Evaluation Error: Resource type not found: Darwin"

This can be fixed by using lower-case "darwin" for osfamily-comparsion.